### PR TITLE
Move electron to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 	"dependencies": {
 		"deepmerge": "^4.2.2",
 		"dot-prop": "^6.0.1",
-		"electron": "^12.0.4",
 		"electron-better-ipc": "^2.0.0",
 		"electron-store": "^8.0.0",
 		"type-fest": "^1.2.0"
@@ -41,6 +40,7 @@
 		"@types/node": "^15.12.0",
 		"@typescript-eslint/eslint-plugin": "^4.26.0",
 		"@typescript-eslint/parser": "^4.26.0",
+		"electron": "^12.0.4",
 		"eslint": "^7.27.0",
 		"ts-node": "^9.1.1",
 		"tsc-watch": "^4.4.0",


### PR DESCRIPTION
Fixes #328 and **thereby reduces the build size of the electron app by about 200MB**